### PR TITLE
Rename if label counter variable

### DIFF
--- a/projects/11/Compiler/internal/compilation_engine/compile_if.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_if.go
@@ -20,7 +20,7 @@ func (ce *CompilationEngine) compileIf() error {
 	ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("keyword", string(token_patterns.IF)))
 	ce.index++
 
-	whileLabelCounter := ce.labelCounterIf
+	ifLabelCounter := ce.labelCounterIf
 	ce.labelCounterIf++
 
 	// '('
@@ -54,11 +54,11 @@ func (ce *CompilationEngine) compileIf() error {
 	ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "{"))
 	ce.index++
 
-	ce.vmWriter.WriteIf(fmt.Sprintf("IF_TRUE%d", whileLabelCounter), ce.componentStack.Count()+1)
-	ce.vmWriter.WriteGoto(fmt.Sprintf("IF_FALSE%d", whileLabelCounter), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteIf(fmt.Sprintf("IF_TRUE%d", ifLabelCounter), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteGoto(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
 
 	// statements
-	ce.vmWriter.WriteLabel(fmt.Sprintf("IF_TRUE%d", whileLabelCounter), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteLabel(fmt.Sprintf("IF_TRUE%d", ifLabelCounter), ce.componentStack.Count()+1)
 	ce.componentStack.Push(ifStatementComponent)
 	if err := ce.compileStatements(); err != nil {
 		return err
@@ -76,7 +76,7 @@ func (ce *CompilationEngine) compileIf() error {
 	// else
 	token = ce.tokens[ce.index]
 	if token.IsElse() {
-		ce.vmWriter.WriteGoto(fmt.Sprintf("IF_END%d", whileLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteGoto(fmt.Sprintf("IF_END%d", ifLabelCounter), ce.componentStack.Count()+1)
 
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("keyword", string(token_patterns.ELSE)))
 		ce.index++
@@ -89,7 +89,7 @@ func (ce *CompilationEngine) compileIf() error {
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "{"))
 		ce.index++
 
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", whileLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
 
 		// statements
 		ce.componentStack.Push(ifStatementComponent)
@@ -105,9 +105,9 @@ func (ce *CompilationEngine) compileIf() error {
 		}
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "}"))
 		ce.index++
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_END%d", whileLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_END%d", ifLabelCounter), ce.componentStack.Count()+1)
 	} else {
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", whileLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- clarify label tracking in `compile_if` by renaming `whileLabelCounter` to `ifLabelCounter`

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_68953638b7ac8320aa691a12f65194ab