### PR TITLE
Simplify VM writer API by dropping indent levels

### DIFF
--- a/projects/11/Compiler/internal/compilation_engine/compile_do.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_do.go
@@ -38,7 +38,7 @@ func (ce *CompilationEngine) compileDo() error {
 	doStatementComponent.Children = append(doStatementComponent.Children, component.New("symbol", ";"))
 	ce.index++
 
-	ce.vmWriter.WritePop(vmwriter.TEMP, 0, ce.componentStack.Count()+1)
+	ce.vmWriter.WritePop(vmwriter.TEMP, 0)
 
 	return nil
 }

--- a/projects/11/Compiler/internal/compilation_engine/compile_expression.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_expression.go
@@ -46,11 +46,11 @@ func (ce *CompilationEngine) compileExpression() error {
 
 		command := arithmeticCommandOperandMap[op]
 		if op == "*" {
-			ce.vmWriter.WriteCall("Math.multiply", 2, ce.componentStack.Count()+1)
+			ce.vmWriter.WriteCall("Math.multiply", 2)
 		} else if op == "/" {
-			ce.vmWriter.WriteCall("Math.divide", 2, ce.componentStack.Count()+1)
+			ce.vmWriter.WriteCall("Math.divide", 2)
 		} else if command != "" {
-			ce.vmWriter.WriteArithmetic(command, ce.componentStack.Count()+1)
+			ce.vmWriter.WriteArithmetic(command)
 		}
 
 		// Operator

--- a/projects/11/Compiler/internal/compilation_engine/compile_if.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_if.go
@@ -54,11 +54,11 @@ func (ce *CompilationEngine) compileIf() error {
 	ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "{"))
 	ce.index++
 
-	ce.vmWriter.WriteIf(fmt.Sprintf("IF_TRUE%d", ifLabelCounter), ce.componentStack.Count()+1)
-	ce.vmWriter.WriteGoto(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteIf(fmt.Sprintf("IF_TRUE%d", ifLabelCounter))
+	ce.vmWriter.WriteGoto(fmt.Sprintf("IF_FALSE%d", ifLabelCounter))
 
 	// statements
-	ce.vmWriter.WriteLabel(fmt.Sprintf("IF_TRUE%d", ifLabelCounter), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteLabel(fmt.Sprintf("IF_TRUE%d", ifLabelCounter))
 	ce.componentStack.Push(ifStatementComponent)
 	if err := ce.compileStatements(); err != nil {
 		return err
@@ -76,7 +76,7 @@ func (ce *CompilationEngine) compileIf() error {
 	// else
 	token = ce.tokens[ce.index]
 	if token.IsElse() {
-		ce.vmWriter.WriteGoto(fmt.Sprintf("IF_END%d", ifLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteGoto(fmt.Sprintf("IF_END%d", ifLabelCounter))
 
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("keyword", string(token_patterns.ELSE)))
 		ce.index++
@@ -89,7 +89,7 @@ func (ce *CompilationEngine) compileIf() error {
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "{"))
 		ce.index++
 
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter))
 
 		// statements
 		ce.componentStack.Push(ifStatementComponent)
@@ -105,9 +105,9 @@ func (ce *CompilationEngine) compileIf() error {
 		}
 		ifStatementComponent.Children = append(ifStatementComponent.Children, component.New("symbol", "}"))
 		ce.index++
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_END%d", ifLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_END%d", ifLabelCounter))
 	} else {
-		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter), ce.componentStack.Count()+1)
+		ce.vmWriter.WriteLabel(fmt.Sprintf("IF_FALSE%d", ifLabelCounter))
 	}
 	return nil
 }

--- a/projects/11/Compiler/internal/compilation_engine/compile_let.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_let.go
@@ -75,8 +75,8 @@ func (ce *CompilationEngine) compileLet() error {
 
 		memorySegment := variableKindMemorySegmentMap[ce.symbolTable.KindOf(objectName)]
 		index := ce.symbolTable.IndexOf(objectName)
-		ce.vmWriter.WritePush(memorySegment, index, ce.componentStack.Count()+1) // push base address of array
-		ce.vmWriter.WriteArithmetic(vmwriter.ADD, ce.componentStack.Count()+1)   // add index: a + i
+		ce.vmWriter.WritePush(memorySegment, index) // push base address of array
+		ce.vmWriter.WriteArithmetic(vmwriter.ADD)   // add index: a + i
 	} else {
 		letStatementComponent.Children = append(letStatementComponent.Children,
 			component.NewVariableComponent("identifier",
@@ -113,12 +113,12 @@ func (ce *CompilationEngine) compileLet() error {
 
 	memorySegmentType := variableKindMemorySegmentMap[ce.symbolTable.KindOf(letName)]
 	if isArray {
-		ce.vmWriter.WritePop(vmwriter.TEMP, 0, ce.componentStack.Count()+1)
-		ce.vmWriter.WritePop(vmwriter.POINTER, 1, ce.componentStack.Count()+1)
-		ce.vmWriter.WritePush(vmwriter.TEMP, 0, ce.componentStack.Count()+1)
-		ce.vmWriter.WritePop(vmwriter.THAT, 0, ce.componentStack.Count()+1)
+		ce.vmWriter.WritePop(vmwriter.TEMP, 0)
+		ce.vmWriter.WritePop(vmwriter.POINTER, 1)
+		ce.vmWriter.WritePush(vmwriter.TEMP, 0)
+		ce.vmWriter.WritePop(vmwriter.THAT, 0)
 	} else {
-		ce.vmWriter.WritePop(memorySegmentType, ce.symbolTable.IndexOf(letName), ce.componentStack.Count()+1)
+		ce.vmWriter.WritePop(memorySegmentType, ce.symbolTable.IndexOf(letName))
 	}
 
 	return nil

--- a/projects/11/Compiler/internal/compilation_engine/compile_return.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_return.go
@@ -45,9 +45,8 @@ func (ce *CompilationEngine) compileReturn() error {
 }
 
 func (ce *CompilationEngine) writeVMReturn() {
-	indentLevel := ce.componentStack.Count() + 1
 	if ce.subroutineInfo.returnType == string(token_patterns.VOID) {
-		ce.vmWriter.WritePush(vmwriter.CONSTANT, 0, indentLevel)
+		ce.vmWriter.WritePush(vmwriter.CONSTANT, 0)
 	}
-	ce.vmWriter.WriteReturn(indentLevel)
+	ce.vmWriter.WriteReturn()
 }

--- a/projects/11/Compiler/internal/compilation_engine/compile_subroutine_body.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_subroutine_body.go
@@ -56,17 +56,16 @@ func (ce *CompilationEngine) compileSubroutineBody() error {
 }
 
 func (ce *CompilationEngine) writeVMFunctionDeclare() {
-	indentLevel := ce.componentStack.Count() + 1
 	ce.vmWriter.WriteFunction(ce.className+"."+ce.subroutineInfo.name, ce.symbolTable.VarCount(symboltable.VAR))
 
 	switch ce.subroutineInfo.functionType {
 	case CONSTRUCTOR:
-		ce.vmWriter.WritePush(vmwriter.CONSTANT, ce.symbolTable.VarCount(symboltable.FIELD), indentLevel)
-		ce.vmWriter.WriteCall("Memory.alloc", 1, indentLevel)
-		ce.vmWriter.WritePop(vmwriter.POINTER, 0, indentLevel)
+		ce.vmWriter.WritePush(vmwriter.CONSTANT, ce.symbolTable.VarCount(symboltable.FIELD))
+		ce.vmWriter.WriteCall("Memory.alloc", 1)
+		ce.vmWriter.WritePop(vmwriter.POINTER, 0)
 	case METHOD:
-		ce.vmWriter.WritePush(vmwriter.ARGUMENT, 0, indentLevel)
-		ce.vmWriter.WritePop(vmwriter.POINTER, 0, indentLevel)
+		ce.vmWriter.WritePush(vmwriter.ARGUMENT, 0)
+		ce.vmWriter.WritePop(vmwriter.POINTER, 0)
 	case FUNCTION:
 		// No additional actions needed for functions
 	default:

--- a/projects/11/Compiler/internal/compilation_engine/compile_subroutine_call.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_subroutine_call.go
@@ -71,10 +71,10 @@ func (ce *CompilationEngine) compileSubroutineCall() error {
 	if isInstanceCall {
 		if instancename == "" {
 			// this.method 呼び出し（例：do draw();）
-			ce.vmWriter.WritePush("pointer", 0, ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush("pointer", 0)
 		} else {
 			// 変数からのメソッド呼び出し（例：square.draw();）
-			ce.vmWriter.WritePush(variableKindMemorySegmentMap[ce.symbolTable.KindOf(instancename)], ce.symbolTable.IndexOf(instancename), ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush(variableKindMemorySegmentMap[ce.symbolTable.KindOf(instancename)], ce.symbolTable.IndexOf(instancename))
 		}
 	}
 
@@ -103,9 +103,9 @@ func (ce *CompilationEngine) compileSubroutineCall() error {
 	ce.index++
 
 	if isInstanceCall {
-		ce.vmWriter.WriteCall(callFunctionName, nArg+1, ce.componentStack.Count()+1)
+		ce.vmWriter.WriteCall(callFunctionName, nArg+1)
 	} else {
-		ce.vmWriter.WriteCall(callFunctionName, nArg, ce.componentStack.Count()+1)
+		ce.vmWriter.WriteCall(callFunctionName, nArg)
 	}
 
 	return nil

--- a/projects/11/Compiler/internal/compilation_engine/compile_term.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_term.go
@@ -25,7 +25,7 @@ func (ce *CompilationEngine) compileTerm() error {
 	if token.IsIntConst() {
 		termComponent.Children = append(termComponent.Children, component.New("integerConstant", token.GetValue()))
 
-		ce.vmWriter.WritePush(vmwriter.CONSTANT, token.GetIntegerVal(), ce.componentStack.Count()+1)
+		ce.vmWriter.WritePush(vmwriter.CONSTANT, token.GetIntegerVal())
 
 		ce.index++
 		return nil
@@ -35,11 +35,11 @@ func (ce *CompilationEngine) compileTerm() error {
 		termComponent.Children = append(termComponent.Children, component.New("stringConstant", token.GetValue()))
 
 		length := len(token.GetStringVal())
-		ce.vmWriter.WritePush(vmwriter.CONSTANT, length, ce.componentStack.Count()+1)
-		ce.vmWriter.WriteCall("String.new", 1, ce.componentStack.Count()+1)
+		ce.vmWriter.WritePush(vmwriter.CONSTANT, length)
+		ce.vmWriter.WriteCall("String.new", 1)
 		for _, char := range token.GetStringVal() {
-			ce.vmWriter.WritePush(vmwriter.CONSTANT, int(char), ce.componentStack.Count()+1)
-			ce.vmWriter.WriteCall("String.appendChar", 2, ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush(vmwriter.CONSTANT, int(char))
+			ce.vmWriter.WriteCall("String.appendChar", 2)
 		}
 
 		ce.index++
@@ -51,12 +51,12 @@ func (ce *CompilationEngine) compileTerm() error {
 
 		switch token.GetKeyword() {
 		case token_patterns.TRUE:
-			ce.vmWriter.WritePush(vmwriter.CONSTANT, 0, ce.componentStack.Count()+1)
-			ce.vmWriter.WriteArithmetic(vmwriter.NOT, ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush(vmwriter.CONSTANT, 0)
+			ce.vmWriter.WriteArithmetic(vmwriter.NOT)
 		case token_patterns.FALSE, token_patterns.NULL:
-			ce.vmWriter.WritePush(vmwriter.CONSTANT, 0, ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush(vmwriter.CONSTANT, 0)
 		case token_patterns.THIS:
-			ce.vmWriter.WritePush(vmwriter.POINTER, 0, ce.componentStack.Count()+1)
+			ce.vmWriter.WritePush(vmwriter.POINTER, 0)
 		}
 
 		ce.index++
@@ -78,9 +78,9 @@ func (ce *CompilationEngine) compileTerm() error {
 
 		switch unaryOperation {
 		case "-":
-			ce.vmWriter.WriteArithmetic(vmwriter.NEG, ce.componentStack.Count()+1)
+			ce.vmWriter.WriteArithmetic(vmwriter.NEG)
 		case "~":
-			ce.vmWriter.WriteArithmetic(vmwriter.NOT, ce.componentStack.Count()+1)
+			ce.vmWriter.WriteArithmetic(vmwriter.NOT)
 		}
 
 		return nil
@@ -152,10 +152,10 @@ func (ce *CompilationEngine) compileTerm() error {
 
 		memorySegment := variableKindMemorySegmentMap[ce.symbolTable.KindOf(objectName)]
 		index := ce.symbolTable.IndexOf(objectName)
-		ce.vmWriter.WritePush(memorySegment, index, ce.componentStack.Count()+1)
-		ce.vmWriter.WriteArithmetic(vmwriter.ADD, ce.componentStack.Count()+1)
-		ce.vmWriter.WritePop(vmwriter.POINTER, 1, ce.componentStack.Count()+1)
-		ce.vmWriter.WritePush(vmwriter.THAT, 0, ce.componentStack.Count()+1)
+		ce.vmWriter.WritePush(memorySegment, index)
+		ce.vmWriter.WriteArithmetic(vmwriter.ADD)
+		ce.vmWriter.WritePop(vmwriter.POINTER, 1)
+		ce.vmWriter.WritePush(vmwriter.THAT, 0)
 		ce.index++
 	} else if token.IsSubroutineCall(nextToken) {
 		// subroutine call
@@ -178,8 +178,7 @@ func (ce *CompilationEngine) compileTerm() error {
 
 		memorySegment := variableKindMemorySegmentMap[ce.symbolTable.KindOf(token.GetIdentifier())]
 		ce.vmWriter.WritePush(memorySegment,
-			ce.symbolTable.IndexOf(token.GetIdentifier()),
-			ce.componentStack.Count()+1)
+			ce.symbolTable.IndexOf(token.GetIdentifier()))
 		ce.index++
 	}
 

--- a/projects/11/Compiler/internal/compilation_engine/compile_while.go
+++ b/projects/11/Compiler/internal/compilation_engine/compile_while.go
@@ -26,7 +26,7 @@ func (ce *CompilationEngine) compileWhile() error {
 	labelCounterWhile := ce.labelCounterWhile
 	ce.labelCounterWhile++
 
-	ce.vmWriter.WriteLabel(fmt.Sprintf("WHILE_EXP%d", labelCounterWhile), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteLabel(fmt.Sprintf("WHILE_EXP%d", labelCounterWhile))
 
 	// '('
 	token = ce.tokens[ce.index]
@@ -59,8 +59,8 @@ func (ce *CompilationEngine) compileWhile() error {
 	whileStatementComponent.Children = append(whileStatementComponent.Children, component.New("symbol", "{"))
 	ce.index++
 
-	ce.vmWriter.WriteArithmetic(vmwriter.NOT, ce.componentStack.Count()+1)
-	ce.vmWriter.WriteIf(fmt.Sprintf("WHILE_END%d", labelCounterWhile), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteArithmetic(vmwriter.NOT)
+	ce.vmWriter.WriteIf(fmt.Sprintf("WHILE_END%d", labelCounterWhile))
 
 	// statements
 	ce.componentStack.Push(whileStatementComponent)
@@ -69,7 +69,7 @@ func (ce *CompilationEngine) compileWhile() error {
 	}
 	whileStatementComponent = ce.componentStack.Pop()
 
-	ce.vmWriter.WriteGoto(fmt.Sprintf("WHILE_EXP%d", labelCounterWhile), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteGoto(fmt.Sprintf("WHILE_EXP%d", labelCounterWhile))
 
 	// '}'
 	token = ce.tokens[ce.index]
@@ -79,7 +79,7 @@ func (ce *CompilationEngine) compileWhile() error {
 	whileStatementComponent.Children = append(whileStatementComponent.Children, component.New("symbol", "}"))
 	ce.index++
 
-	ce.vmWriter.WriteLabel(fmt.Sprintf("WHILE_END%d", labelCounterWhile), ce.componentStack.Count()+1)
+	ce.vmWriter.WriteLabel(fmt.Sprintf("WHILE_END%d", labelCounterWhile))
 
 	return nil
 }

--- a/projects/11/Compiler/internal/vm_writer/vm_writer.go
+++ b/projects/11/Compiler/internal/vm_writer/vm_writer.go
@@ -33,15 +33,15 @@ const (
 )
 
 type IVMWriter interface {
-	WritePush(segment Segment, index int, indentLevel int)
-	WritePop(segment Segment, index int, indentLevel int)
-	WriteArithmetic(command ArithmeticCommand, indentLevel int)
-	WriteLabel(label string, indentLevel int)
-	WriteGoto(label string, indentLevel int)
-	WriteIf(label string, indentLevel int)
-	WriteCall(name string, nArgs int, indentLevel int)
+	WritePush(segment Segment, index int)
+	WritePop(segment Segment, index int)
+	WriteArithmetic(command ArithmeticCommand)
+	WriteLabel(label string)
+	WriteGoto(label string)
+	WriteIf(label string)
+	WriteCall(name string, nArgs int)
 	WriteFunction(name string, nVars int)
-	WriteReturn(indentLevel int)
+	WriteReturn()
 }
 
 type VMWriter struct {
@@ -52,48 +52,44 @@ func New(w io.Writer) IVMWriter {
 	return &VMWriter{writer: w}
 }
 
-func (w *VMWriter) WritePush(segment Segment, index int, indentLevel int) {
-	w.writeLine(indentLevel, "push %s %d", segment, index)
+func (w *VMWriter) WritePush(segment Segment, index int) {
+	w.writeLine("push %s %d", segment, index)
 }
 
-func (w *VMWriter) WritePop(segment Segment, index int, indentLevel int) {
-	w.writeLine(indentLevel, "pop %s %d", segment, index)
+func (w *VMWriter) WritePop(segment Segment, index int) {
+	w.writeLine("pop %s %d", segment, index)
 }
 
-func (w *VMWriter) WriteArithmetic(command ArithmeticCommand, indentLevel int) {
-	w.writeLine(indentLevel, "%s", command)
+func (w *VMWriter) WriteArithmetic(command ArithmeticCommand) {
+	w.writeLine("%s", command)
 }
 
-func (w *VMWriter) WriteLabel(label string, indentLevel int) {
-	w.writeLine(indentLevel, "label %s", label)
+func (w *VMWriter) WriteLabel(label string) {
+	w.writeLine("label %s", label)
 }
 
-func (w *VMWriter) WriteGoto(label string, indentLevel int) {
-	w.writeLine(indentLevel, "goto %s", label)
+func (w *VMWriter) WriteGoto(label string) {
+	w.writeLine("goto %s", label)
 }
 
-func (w *VMWriter) WriteIf(label string, indentLevel int) {
-	w.writeLine(indentLevel, "if-goto %s", label)
+func (w *VMWriter) WriteIf(label string) {
+	w.writeLine("if-goto %s", label)
 }
 
-func (w *VMWriter) WriteCall(name string, nArgs int, indentLevel int) {
-	w.writeLine(indentLevel, "call %s %d", name, nArgs)
+func (w *VMWriter) WriteCall(name string, nArgs int) {
+	w.writeLine("call %s %d", name, nArgs)
 }
 
 func (w *VMWriter) WriteFunction(name string, nVars int) {
-	w.writeLine(0, "function %s %d", name, nVars)
+	w.writeLine("function %s %d", name, nVars)
 }
 
-func (w *VMWriter) WriteReturn(indentLevel int) {
-	w.writeLine(indentLevel, "return")
+func (w *VMWriter) WriteReturn() {
+	w.writeLine("return")
 }
 
-func (w *VMWriter) writeLine(indentLevel int, format string, a ...interface{}) {
-	indent := ""
-	for i := 0; i < indentLevel; i++ {
-		indent += "  "
-	}
-	_, err := fmt.Fprintf(w.writer, "%s%s\n", indent, fmt.Sprintf(format, a...))
+func (w *VMWriter) writeLine(format string, a ...interface{}) {
+	_, err := fmt.Fprintf(w.writer, "%s\n", fmt.Sprintf(format, a...))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary
- remove `indentLevel` arguments from the VM writer interface and implementation
- adjust compilation engine to call VM writer without indentation

## Testing
- `go test ./...` *(fails: golang.org/toolchain@v0.0.1-go1.24.3.linux-amd64: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68959b5a6c7c83209c6242c04f6fd557